### PR TITLE
work on debian based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Features
 --------
 
 Features let you configure call parking and special numbers that trigger
-special functionality. The `asterisk::feature` defined type helps you
+special functionality. The `asterisk::cfg::feature` defined type helps you
 configuring such features. The `options` parameter is mandatory.
 
 Define features that are contained within feature group "myfeaturegroup":
@@ -417,18 +417,18 @@ $ft_options = {
   'pausemonitor'   => '#1,self/callee,Pausemonitor',
   'unpauseMonitor' => '#3,self/callee,UnPauseMonitor',
 }
-asterisk::feature { 'myfeaturegroup':
+asterisk::cfg::feature { 'myfeaturegroup':
   options => $ft_options,
 }
 ```
 
 A special section in the features configuration file, namely
 `[applicationmaps]` lets you define global features. The
-`asterisk::feature::applicationmap` defined type helps you configure such a
+`asterisk::cfg::feature::applicationmap` defined type helps you configure such a
 global feature. The `feature` and `value` parameters are mandatory:
 
 ```puppet
-asterisk::feature::applicationmap { 'pausemonitor':
+asterisk::cfg::feature::applicationmap { 'pausemonitor':
   feature => 'pausemonitor',
   value   => '#1,self/callee,Pausemonitor',
 }
@@ -456,11 +456,11 @@ in this context.
 
 Another special context, `applicationmap`, lets you configure dynamic features.
 To set entries in this context, you should use the
-`asterisk::feature::applicationmap` defined type. Note also that for dynamic
+`asterisk::cfg::feature::applicationmap` defined type. Note also that for dynamic
 features to work the DYNAMIC_FEATURES channel variable must be set by listing
 features enabled in the channel, separated by '#'.
 
-To configure additional feature contexts, you can use the `asterisk::feature`
+To configure additional feature contexts, you can use the `asterisk::cfg::feature`
 defined type.
 
 Queues

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -218,7 +218,19 @@ class asterisk (
   # mess everything up. You can read about this at:
   # http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html#known-issues
   anchor { 'asterisk::begin': }
-  -> class { '::asterisk::repos': }
+  -> 
+  case $::operatingsystem {
+    'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon', 'OracleLinux': {
+        # rhel-based
+        class { '::asterisk::repos::rhel': }
+    }
+    'Debian', 'Ubuntu': {
+        class { '::asterisk::repos::debian': }
+    }
+    default: {
+      fail("\"${module_name}\" provides no packages for \"${::operatingsystem}\"")
+    }
+  }
   -> class { '::asterisk::install': }
   -> class { '::asterisk::config': }
   ~> class { '::asterisk::service': }

--- a/manifests/repos/debian.pp
+++ b/manifests/repos/debian.pp
@@ -1,0 +1,6 @@
+# Installs the repos needed to install asterisk and it's components
+#
+class asterisk::repos::debian {
+
+    # nothing right now
+}

--- a/manifests/repos/rhel.pp
+++ b/manifests/repos/rhel.pp
@@ -1,6 +1,6 @@
 # Installs the repos needed to install asterisk and it's components
 #
-class asterisk::repos {
+class asterisk::repos::rhel {
 
 
   if $asterisk::real_manage_package['manage_repos'] == 'all' or $asterisk::real_manage_package['manage_repos'] == 'only-asterisk'

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,12 @@
         "6",
         "7"
       ]
+    },
+    { "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
     }
   ],
   "tags": [
@@ -33,4 +39,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
the original module this was based on worked on debian-based, but now only works on RHEL based.

this is reasonably limited as it just uses system packages. there are no official apt repos for asterisk for some reason so i left asterisk::repos::debian empty for later fill-in if necessary.

this is far, far more time effective for me than starting completely from scratch. 